### PR TITLE
Inform Spinnaker of the Concourse build

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 - `spinnaker_api`: *Required* the url of the Spinnaker api microservice.
 - `spinnaker_application`: *Required* The Spinnaker application you would like to trigger.
 - `spinnaker_pipeline`: *Required* The Spinnaker pipeline you would like to trigger.
-- `client_x509_cert`: *Required* Client [certificate](https://www.spinnaker.io/setup/security/authentication/x509/) to authenticate with Spinnaker.
-- `client_x509_key`: *Required* Client [key](https://www.spinnaker.io/setup/security/authentication/x509/) to authenticate with Spinnaker.
+- `spinnaker_x509_cert`: *Required* Client [certificate](https://www.spinnaker.io/setup/security/authentication/x509/) to authenticate with Spinnaker.
+- `spinnaker_x509_key`: *Required* Client [key](https://www.spinnaker.io/setup/security/authentication/x509/) to authenticate with Spinnaker.
 - `statuses`: *Optional* Array of Spinnaker pipeline execution statuses. Currently supported statuses by Spinnaker: [NOT_STARTED, RUNNING, PAUSED, SUSPENDED, SUCCEEDED, FAILED_CONTINUE, TERMINAL, CANCELED, REDIRECT, STOPPED, SKIPPED, BUFFERED] - [Reference](https://github.com/spinnaker/gate/blob/1cb00104f925e484d7a7a333bf07bd149adb0464/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ExecutionsController.java#L82).
    - if specified, the status will be used to filter the pipeline execution statuses when detecting new versions during the `check` step.
    - if specified ,the `put` step will block until the specified status(es) is reached.
@@ -99,8 +99,8 @@ resources:
     type: spinnaker
     source:
       spinnaker_api: ((spinnaker-api))
-      client_x509_cert: ((client-x509-cert))
-      client_x509_key: ((client-x509-key))
+      spinnaker_x509_cert: ((client-x509-cert))
+      spinnaker_x509_key: ((client-x509-key))
       spinnaker_application: samplespinnakerapp
       spinnaker_pipeline: samplespinnakerpipeline
       statuses:

--- a/concourse/models.go
+++ b/concourse/models.go
@@ -67,6 +67,11 @@ type IntermediateMetadata struct {
 	StartTime       int64  `json:"startTime"`
 	EndTime         int64  `json:"endTime"`
 	Status          string `json:"status"`
+	Stages          []struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+		Name string `json:"name"`
+	}
 }
 
 type InResponse struct {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/pivotal-cf/spinnaker-resource
 
+go 1.14
+
 require (
 	github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286
 	github.com/onsi/ginkgo v1.6.0


### PR DESCRIPTION
- Added a call to /concourse/stage/start during the get step to inform Spinnaker of the Concourse build job and number for that stage so Spinnaker can monitor it. 
- Update readme with the correct source parameters